### PR TITLE
Test: E2e testing integration

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         source: ~/.kube
         target: /home/terraform/.kube
       - type: bind
-        source: ../.certs/root/root.crt
+        source: ../.certs/intermediate/ca.crt
         target: /etc/ssl/certs/root.crt
         read_only: true
       - type: bind

--- a/.docker/docker-compose.common.yml
+++ b/.docker/docker-compose.common.yml
@@ -4,7 +4,7 @@ services:
   nextjs-grpc-infra:
     container_name: nextjs-grpc-infra
     # image: utkusarioglu/tf-k8s-devcontainer:1.4.experiment-feat-devcontainer-features-10
-    image: utkusarioglu/tf-k8s-devcontainer:1.4.experiment-feat-devcontainer-features-15
+    image: utkusarioglu/tf-k8s-devcontainer:1.4.experiment-feat-devcontainer-features-19
     environment:
       TZ: Etc/UTC0
       NODES_VOLUMES_ROOT: /dev/xvdf

--- a/.docker/docker-compose.e2e.ci.yml
+++ b/.docker/docker-compose.e2e.ci.yml
@@ -1,0 +1,101 @@
+version: "3.11"
+
+services:
+  nextjs-grpc-infra:
+    container_name: nextjs-grpc-infra
+    image: utkusarioglu/tf-k8s-devcontainer:1.4.experiment-feat-devcontainer-features-15
+    working_dir: /utkusarioglu-com/projects/nextjs-grpc/infra
+    user: 0:0
+    tty: true
+    network_mode: host
+    environment:
+      HOST_VOLUMES_ROOT: ${WORKSPACE_PATH}/volumes/nextjs-grpc
+      HOST_SOURCE_CODE_ROOT: ${WORKSPACE_PATH}
+      VAULT_ADDR: https://vault.nextjs-grpc.utkusarioglu.com:8200
+      CLUSTER_HOST: local.dev.k3d.nextjs-grpc.projects.utkusarioglu.com
+      PROJECT_ROOT_ABSPATH: ${WORKSPACE_PATH}
+      K3D_DEV_LOCAL_DEPLOYMENT_MODE: ${K3D_DEV_LOCAL_DEPLOYMENT_MODE}
+    extra_hosts:
+      host-gateway: host-gateway
+    volumes:
+      - type: bind
+        source: ../../infra/.certs/intermediate/ca.crt
+        target: /usr/local/share/ca-certificates/cluster-ca.crt
+
+  nextjs-grpc-e2e:
+    container_name: nextjs-grpc-e2e
+    image: cypress/included:$CYPRESS_VERSION
+    user: 0:0
+    tty: true
+    working_dir: /utkusarioglu-com/projects/nextjs-grpc/e2e
+    network_mode: host
+    entrypoint: /bin/sh -c "while sleep 1000; do :; done"
+    environment:
+      # E2E_BROWSERS: chrome
+      E2E_VIDEO_PADDING: 500,150
+      # BASE_URL: nextjs-grpc.utkusarioglu.com
+      # E2E_VIEWPORT_SIZES: 480x720
+      BASE_URL: nextjs-grpc.utkusarioglu.com
+      E2E_VIEWPORT_SIZES: 1920x1080,540x1200,480x850,480x720
+      E2E_BROWSERS: chrome,firefox,edge
+
+    extra_hosts:
+      nextjs-grpc.utkusarioglu.com: host-gateway
+    volumes:
+      - type: bind
+        source: ../../e2e/.env
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e/.env
+      - type: bind
+        source: ../../e2e/package.json
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e/package.json
+      - type: bind
+        source: ../../e2e/scripts
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e/scripts
+      - type: bind
+        source: ../../e2e/.cypress
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e/cypress
+      - type: bind
+        source: ../../e2e/cypress.config.js
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e/cypress.config.js
+      - type: bind
+        source: ../../e2e/.cypress/cache/node_modules
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e/node_modules
+      - type: bind
+        source: ../../e2e/.cypress/cache/cypress
+        target: /root/.cache/cypress
+      - type: bind
+        source: ../../e2e/.yarnrc.yml
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e/.yarnrc.yml
+      - type: bind
+        source: ../../e2e/.yarn
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e/.yarn
+      - type: bind
+        source: ../../e2e/yarn.lock
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e/yarn.lock
+      - type: bind
+        source: ../../infra/.certs/intermediate/ca.crt
+        target: /utkusarioglu-com/projects/nextjs-grpc/e2e/.certs/intermediate/ca.crt
+      - type: bind
+        source: ../../e2e/.certs/intermediate/ca.crt
+        target: /usr/local/share/ca-certificates/cluster-ca.crt
+
+# docker run \
+#   --rm \
+#   --user 0:0 \
+#   -t \
+#   -v "$repo_dir/.env:$workdir/.env" \
+#   -v "$repo_dir/package.json:$workdir/package.json" \
+#   -v "$repo_dir/scripts:$workdir/scripts" \
+#   -v "$repo_dir/.cypress:$workdir/cypress" \
+#   -v "$repo_dir/cypress.config.js:$workdir/cypress.config.js" \
+#   -v "$repo_dir/.cypress/cache/node_modules:$workdir/node_modules" \
+#   -v "$repo_dir/.cypress/cache/cypress:
+#   -v "$repo_dir/.yarnrc.yml:$workdir/.yarnrc.yml" \
+#   -v "$repo_dir/.yarn:$workdir/.yarn" \
+#   -v "$repo_dir/yarn.lock:$workdir/yarn.lock" \
+#   -w $workdir \
+#   --network host \
+#   --name nextjs-grpc-e2e \
+#   --add-host "$base_url:127.0.0.1" \
+#   --entrypoint scripts/run-cypress-tests.sh \
+#   cypress/included:$cypress_version

--- a/.github/workflows/k3d-dev-local.e2e.test.wfc.yml
+++ b/.github/workflows/k3d-dev-local.e2e.test.wfc.yml
@@ -101,6 +101,7 @@ jobs:
           - infraRepoRelPath: infra
             artifactsRelPath: artifacts
             logsRelPath: logs
+            tgCacheEnabled: false
 
     steps:
       - name: Checkout `certificates`
@@ -261,6 +262,7 @@ jobs:
         run: mkdir -p .cypress/cache/{node_modules,cypress}
 
       - name: Restore terragrunt cache
+        if: ${{ matrix.vars.tgCacheEnabled }}
         id: terragrunt-cache-restore
         uses: actions/cache/restore@v3
         with:
@@ -399,6 +401,7 @@ jobs:
           echo '</cache/terragrunt>'
 
       - name: Save Terragrunt cache
+        if: ${{ matrix.vars.tgCacheEnabled }}
         id: terragrunt-cache-save
         uses: actions/cache/save@v3
         with:

--- a/.github/workflows/k3d-dev-local.e2e.test.wfc.yml
+++ b/.github/workflows/k3d-dev-local.e2e.test.wfc.yml
@@ -1,0 +1,431 @@
+name: Test K3d Dev Local
+
+on:
+  workflow_call:
+    inputs:
+      certificatesRef:
+        required: false
+        default: main
+        type: string
+      e2eRef:
+        required: false
+        default: main
+        type: string
+      frontendRef:
+        required: false
+        default: main
+        type: string
+      grafanaRef:
+        required: false
+        default: main
+        type: string
+      infraRef:
+        required: false
+        default: main
+        type: string
+      jaegerRef:
+        required: false
+        default: main
+        type: string
+      lokiRef:
+        required: false
+        default: main
+        type: string
+      msRef:
+        required: false
+        default: main
+        type: string
+      notebooksRef:
+        required: false
+        default: main
+        type: string
+      otelCollectorsRef:
+        required: false
+        default: main
+        type: string
+      prometheusRef:
+        required: false
+        default: main
+        type: string
+      protoRef:
+        required: false
+        default: main
+        type: string
+      rbacRef:
+        required: false
+        default: main
+        type: string
+
+      webServerImageTag: 
+        required: false
+        type: string
+      msImageTag: 
+        required: false
+        type: string
+
+jobs:
+  test-k3d-dev-local:
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
+    strategy:
+      matrix: 
+        certificatesRef: 
+          - "${{ inputs.certificatesRef }}"
+        e2eRef: 
+          - "${{ inputs.e2eRef }}"
+        frontendRef: 
+          - "${{ inputs.frontendRef }}"
+        grafanaRef: 
+          - "${{ inputs.grafanaRef }}"
+        infraRef: 
+          - "${{ inputs.infraRef }}"
+        jaegerRef: 
+          - "${{ inputs.jaegerRef }}"
+        lokiRef: 
+          - "${{ inputs.lokiRef }}"
+        msRef: 
+          - "${{ inputs.msRef }}"
+        notebooksRef: 
+          - "${{ inputs.notebooksRef }}"
+        otelCollectorsRef: 
+          - "${{ inputs.otelCollectorsRef }}"
+        prometheusRef: 
+          - "${{ inputs.prometheusRef }}"
+        protoRef: 
+          - "${{ inputs.protoRef }}"
+        rbacRef: 
+          - "${{ inputs.rbacRef }}"
+
+        vars: 
+          - infraRepoRelPath: infra
+            artifactsRelPath: artifacts
+            logsRelPath: logs
+
+    steps:
+      - name: Checkout `certificates`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-certificates
+          ref: ${{ matrix.certificatesRef }}
+          fetch-depth: 0
+          path: certificates
+
+      - name: Checkout `e2e`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-e2e
+          ref: ${{ matrix.e2eRef }}
+          fetch-depth: 0
+          path: e2e
+
+      - name: Checkout `frontend`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-frontend
+          ref: ${{ matrix.frontendRef }}
+          fetch-depth: 0
+          path: frontend
+      
+      - name: Checkout `grafana`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-grafana
+          ref: ${{ matrix.grafanaRef }}
+          fetch-depth: 0
+          path: grafana
+
+      - name: Checkout `infra`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-infra
+          ref: ${{ matrix.infraRef }}
+          fetch-depth: 0
+          path: infra
+
+      - name: Checkout `jaeger`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-jaeger
+          ref: ${{ matrix.jaegerRef }}
+          fetch-depth: 0
+          path: jaeger
+      
+      - name: Checkout `loki`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-loki
+          ref: ${{ matrix.lokiRef }}
+          fetch-depth: 0
+          path: loki
+      
+      - name: Checkout `ms`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-ms
+          ref: ${{ matrix.msRef }}
+          fetch-depth: 0
+          path: ms
+      
+      - name: Checkout `notebooks`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-notebooks
+          ref: ${{ matrix.notebooksRef }}
+          fetch-depth: 0
+          path: notebooks
+      
+      - name: Checkout `otel-collectors`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-otel-collectors
+          ref: ${{ matrix.otelCollectorsRef }}
+          fetch-depth: 0
+          path: otel-collectors
+      
+      - name: Checkout `prometheus`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-prometheus
+          ref: ${{ matrix.prometheusRef }}
+          fetch-depth: 0
+          path: prometheus
+
+      - name: Checkout `proto`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-proto
+          ref: ${{ matrix.protoRef }}
+          fetch-depth: 0
+          path: proto
+
+      - name: Checkout `rbac`
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-rbac
+          ref: ${{ matrix.rbacRef }}
+          fetch-depth: 0
+          path: rbac
+      
+      - name: Migrate vars and secrets files 
+        working-directory: infra
+        shell: bash
+        run: |
+          TEMP_B64_SECRETS_ABSPATH=/tmp/secrets.b64
+          TEMP_ZIP_SECRETS_ABSPATH=/tmp/secrets.zip
+          echo '${{ secrets.SECRET_FILES }}' > $TEMP_B64_SECRETS_ABSPATH
+          cat $TEMP_B64_SECRETS_ABSPATH | base64 --decode \
+            > $TEMP_ZIP_SECRETS_ABSPATH
+          unzip -o $TEMP_ZIP_SECRETS_ABSPATH
+          rm $TEMP_B64_SECRETS_ABSPATH $TEMP_ZIP_SECRETS_ABSPATH
+
+      - name: Copy CA to e2e
+        run: |
+          mkdir -p e2e/.certs/intermediate
+          pwd
+          cp \
+            infra/.certs/intermediate/ca.crt \
+            e2e/.certs/intermediate/ca.crt
+          cat e2e/.certs/intermediate/ca.crt
+
+      - name: Remove risky config
+        working-directory: infra/src/targets
+        run: rm -rf aws
+        
+      - name: e2e env vars
+        working-directory: e2e
+        env: 
+          BASE_URL: nextjs-grpc.utkusarioglu.com
+          E2E_VIEWPORT_SIZES: 1920x1080,480x720
+          E2E_BROWSERS: chrome,firefox,edge
+          E2E_VIDEO_PADDING: 500,150
+          # E2E_BROWSERS: chrome
+          # E2E_VIEWPORT_SIZES: 480x720
+        run: |
+          required_values='
+            E2E_BROWSERS 
+            E2E_VIDEO_PADDING 
+            BASE_URL 
+            E2E_VIEWPORT_SIZES
+          '
+
+          touch .env
+          for var in $required_values; do
+            echo "${var}=${!var}"
+          done
+          cat .env
+      
+      - name: Create e2e cache paths
+        working-directory: e2e
+        shell: bash
+        run: mkdir -p .cypress/cache/{node_modules,cypress}
+
+      - name: Restore terragrunt cache
+        id: terragrunt-cache-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            infra/.cache
+          key: k3d-dev-local
+          restore-keys: |
+            k3d-dev-
+            k3d-
+      
+      - name: Start devcontainer
+        working-directory: infra
+        run: |
+          scripts/ci/start-devcontainer.sh \
+            $GITHUB_WORKSPACE \
+            '12.17.2' \
+            'no_observability'
+
+      - name: Alter Infra Hosts
+        working-directory: infra
+        run: |
+          docker exec -t nextjs-grpc-infra \
+            scripts/hosts-entries/add.sh host-gateway
+
+      - name: Update ca certs in containers
+        run: |
+          for container in infra e2e; do
+            docker exec -t nextjs-grpc-$container bash -c '
+              update-ca-certificates --fresh
+            '
+          done
+
+      - name: Create infrastructure
+        working-directory: infra
+        run: scripts/ci/create-infrastructure.sh 'src/targets/k3d/dev/local'
+      
+      - name: Sleep
+        run: |
+          duration=60
+          echo "Sleeping for $duration while cluster stabilizes…"
+          sleep $duration
+
+      # - name: Curl from infra
+      #   if: ${{ always() }}
+      #   run: |
+      #     docker exec -t nextjs-grpc-infra bash -c '
+      #       echo "<insecure home>"
+      #       curl http://nextjs-grpc.utkusarioglu.com | head -n1 -c80
+      #       echo "</insecure home>"
+      #       echo "<ssl home --insecure>"
+      #       curl --insecure https://nextjs-grpc.utkusarioglu.com | head -n1 -c80
+      #       echo "</ssl home --insecure>"
+      #       echo "<ssl home>"
+      #       curl https://nextjs-grpc.utkusarioglu.com | head -n1 -c80
+      #       echo "</ssl home>"
+      #       echo "<ssl login>"
+      #       curl https://nextjs-grpc.utkusarioglu.com/login | head -n1 -c80
+      #       echo "</ssl login>"
+      #     '
+      
+      # - name: Curl from e2e
+      #   if: ${{ always() }}
+      #   run: |
+      #     docker exec -t nextjs-grpc-e2e bash -c '
+      #       apt update && apt install -y curl
+      #       echo "<insecure home>"
+      #       curl http://nextjs-grpc.utkusarioglu.com | head -n1 -c80
+      #       echo "</insecure home>"
+      #       echo "<ssl home --insecure>"
+      #       curl --insecure https://nextjs-grpc.utkusarioglu.com | head -n1 -c80
+      #       echo "</ssl home --insecure>"
+      #       echo "<ssl home>"
+      #       curl https://nextjs-grpc.utkusarioglu.com | head -n1 -c80
+      #       echo "</ssl home>"
+      #       echo "<ssl login>"
+      #       curl https://nextjs-grpc.utkusarioglu.com/login | head -n1 -c80
+      #       echo "</ssl login>"
+      #     '
+
+      - name: Prep e2e test dependencies
+        if: ${{ always() }}
+        working-directory: e2e
+        run: |
+          docker exec -t nextjs-grpc-e2e scripts/prep-cypress-tests.sh
+      
+      - name: Run e2e tests
+        if: ${{ always() }}
+        working-directory: e2e
+        # env: 
+        #   # E2E_VIEWPORT_SIZES: 1920x1080,480x720
+        #   # E2E_BROWSERS: chrome,firefox,edge
+        #   E2E_BROWSERS: chrome
+        #   E2E_VIDEO_PADDING: 500,150
+        #   BASE_URL: nextjs-grpc.utkusarioglu.com
+        #   E2E_VIEWPORT_SIZES: 480x720
+        run: |
+          docker exec -t nextjs-grpc-e2e scripts/run-cypress-tests.sh
+          
+      - name: Publish logs
+        if: ${{ always() }}
+        run: |
+          docker exec -t nextjs-grpc-infra bash -c '
+            for ns in api ms observability; do
+              kubectl -n $ns get po 
+              pods=$(kubectl -n $ns get po | yq ".items[] | .metadata.name")
+              echo "<Pods in ns $ns>"
+              echo $pods
+              echo "<Pods in ns $ns>"
+
+              for pod in $pods; do
+                echo "<Logs: $ns/$pod>"
+                kubectl -n $ns logs $pod
+                echo "</Logs: $ns/$pod>"
+              done
+            done
+          '
+
+      - name: Alter infra cache path permissions
+        working-directory: infra
+        run: |
+            sudo chown -R "$(id -u):$(id -g)" .cache
+            ls -al .cache
+
+      - name: Terragrunt cache ls
+        if: ${{ always() }}
+        working-directory: infra
+        run: |
+          echo '<.>'
+          ls
+          echo '</.>'
+          echo '<cache>'
+          ls .cache
+          echo '</cache>'
+          echo '<cache/terragrunt>'
+          ls .cache/terragrunt
+          echo '</cache/terragrunt>'
+
+      - name: Save Terragrunt cache
+        id: terragrunt-cache-save
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            infra/.cache
+          key: k3d-dev-local
+          restore-keys: |
+            k3d-dev-
+            k3d-
+
+      - name: Save infra artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: utkusarioglu-nextjs-grpc-infra-artifacts
+          path: infra/${{ matrix.vars.artifactsRelPath }}
+
+      - name: Save infra logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: utkusarioglu-nextjs-grpc-infra-logs
+          path: infra/${{ matrix.vars.logsRelPath }}
+
+      - name: Save e2e Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: utkusarioglu-nextjs-grpc-e2e-artifacts
+          path: e2e/.cypress/artifacts

--- a/.github/workflows/k3d-dev-local.integration.test.wfc.yml
+++ b/.github/workflows/k3d-dev-local.integration.test.wfc.yml
@@ -68,31 +68,31 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: 
-        certificates: 
+        certificatesRef: 
           - "${{ inputs.certificatesRef }}"
-        e2e: 
+        e2eRef: 
           - "${{ inputs.e2eRef }}"
-        frontend: 
+        frontendRef: 
           - "${{ inputs.frontendRef }}"
-        grafana: 
+        grafanaRef: 
           - "${{ inputs.grafanaRef }}"
-        infra: 
+        infraRef: 
           - "${{ inputs.infraRef }}"
-        jaeger: 
+        jaegerRef: 
           - "${{ inputs.jaegerRef }}"
-        loki: 
+        lokiRef: 
           - "${{ inputs.lokiRef }}"
-        ms: 
+        msRef: 
           - "${{ inputs.msRef }}"
-        notebooks: 
+        notebooksRef: 
           - "${{ inputs.notebooksRef }}"
-        otel_collectors: 
+        otelCollectorsRef: 
           - "${{ inputs.otelCollectorsRef }}"
-        prometheus: 
+        prometheusRef: 
           - "${{ inputs.prometheusRef }}"
-        proto: 
+        protoRef: 
           - "${{ inputs.protoRef }}"
-        rbac: 
+        rbacRef: 
           - "${{ inputs.rbacRef }}"
 
         vars: 
@@ -239,7 +239,7 @@ jobs:
       - name: Register Root CA
         working-directory: infra
         run: |
-          cp .certs/root/root.crt /usr/local/share/ca-certificates/
+          cp .certs/intermediate/ca.crt /usr/local/share/ca-certificates/
           update-ca-certificates
 
       - name: Alter hosts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,8 +12,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  infra-test-web:
-    uses: ./.github/workflows/k3d-dev-local.test.wfc.yml
+  k3d-dev-local-integration-test:
+    uses: ./.github/workflows/k3d-dev-local.integration.test.wfc.yml
+    secrets: inherit
+    with:
+      infraRef: ${{ github.head_ref }}
+
+  k3d-dev-local-e2e-test:
+    uses: ./.github/workflows/k3d-dev-local.e2e.test.wfc.yml
     secrets: inherit
     with:
       infraRef: ${{ github.head_ref }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,17 +5,33 @@ on:
     tags:
       - "**.**.**"
       - "experiment/**/**/**"
-    paths:
-      - src/**
-      - .github/workflows/push.yml
-      - .github/workflows/k3d-dev-local.test.wfc.yml
+    # paths:
+    #   - src/**
+    #   - .github/workflows/push.yml
+    #   - .github/workflows/k3d-dev-local.integration.test.wfc.yml
+    #   - .github/workflows/k3d-dev-local.e2e.test.wfc.yml
   workflow_dispatch:
 
 jobs:
-  infra-test-web:
-    uses: ./.github/workflows/k3d-dev-local.test.wfc.yml
+  k3d-dev-local-integration-test:
+    uses: ./.github/workflows/k3d-dev-local.integration.test.wfc.yml
     secrets: inherit
     with:
       infraRef: ${{ github.ref_name }}
-      frontendRef: experiment/test/workflow-calls
-      msRef: experiment/chore/workflow-call
+      # frontendRef: experiment/test/workflow-calls
+      # msRef: experiment/chore/workflow-call
+      e2eRef: experiment/chore/infra-integration
+
+  k3d-dev-local-e2e-test:
+    uses: ./.github/workflows/k3d-dev-local.e2e.test.wfc.yml
+    secrets: inherit
+    with:
+      infraRef: ${{ github.ref_name }}
+      # e2eRef: experiment/chore/infra-integration
+
+  # aws-dev-euc1-e2e-test:
+  #   uses: ./.github/workflows/aws-dev-euc1.e2e.test.wfc.yml
+  #   secrets: inherit
+  #   with:
+  #     infraRef: ${{ github.ref_name }}
+  #     e2eRef: experiment/chore/infra-integration

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
       infraRef: ${{ github.ref_name }}
       # frontendRef: experiment/test/workflow-calls
       # msRef: experiment/chore/workflow-call
-      e2eRef: experiment/chore/infra-integration
+      # e2eRef: experiment/chore/infra-integration
 
   k3d-dev-local-e2e-test:
     uses: ./.github/workflows/k3d-dev-local.e2e.test.wfc.yml

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ terraform.rc
 
 *.env
 !*.env.example
+*.env.ci
+!*.env.ci.example
 
 /vars/**
 !/vars/**.example
@@ -60,3 +62,5 @@ terraform.rc
 modules/vault/artifacts
 
 TODO.md
+
+.infracost

--- a/.usage/aws.yml
+++ b/.usage/aws.yml
@@ -1,0 +1,11 @@
+version: 0.1
+resource_usage:
+  module.records.aws_route53_record.this["records-mock.nextjs-grpc A"]:
+    monthly_standard_queries: 1100000000      # Monthly number of Standard queries.
+    monthly_latency_based_queries: 1200000000 # Monthly number of Latency Based Routing queries.
+    monthly_geo_queries: 1500000000           # Monthly number of Geo DNS and Geoproximity queries.
+  module.vpc.aws_nat_gateway.this[0]:
+    monthly_data_processed_gb: 100 # Monthly data processed by the NAT Gateway in GB.
+  # aws_lambda_function.hi:
+  #   monthly_requests: 0 # Monthly requests to the Lambda function.
+  #   request_duration_ms: 0 # Average duration of each request in milliseconds.

--- a/scripts/aws-cost.sh
+++ b/scripts/aws-cost.sh
@@ -1,0 +1,3 @@
+infracost breakdown \
+  --path src/targets/aws/dev/eu-central-1  \
+  --usage-file .usage/aws.yml

--- a/scripts/ci/create-infrastructure.sh
+++ b/scripts/ci/create-infrastructure.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+target_path=$1
+
+echo $AWS_ROLE_ARN
+
+if [ -z "$target_path" ]; then
+  echo "Error: Target path needs to be set"
+  exit 1
+fi
+
+cd "$target_path"
+pwd
+
+container_command='
+  terragrunt run-all apply \
+    --auto-approve \
+    --terragrunt-non-interactive \
+    --terragrunt-download-dir /utkusarioglu-com/projects/nextjs-grpc/infra/.cache/terragrunt
+'
+
+docker exec -t nextjs-grpc-infra bash -c "$container_command"

--- a/scripts/ci/destroy-infrastructure.sh
+++ b/scripts/ci/destroy-infrastructure.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+target_path=$1
+
+if [ -z "$target_path" ]; then
+  echo "Error: Target path needs to be set"
+  exit 1
+fi
+
+cd "$target_path"
+pwd
+
+container_command='
+  terragrunt run-all destroy --auto-approve --terragrunt-non-interactive
+'
+
+docker exec -t nextjs-grpc-infra bash -c "$container_command"

--- a/scripts/ci/start-devcontainer.sh
+++ b/scripts/ci/start-devcontainer.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+WORKSPACE_PATH=$1
+CYPRESS_VERSION=$2
+K3D_DEV_LOCAL_DEPLOYMENT_MODE=$3
+
+REQUIRED_VARS='
+  WORKSPACE_PATH 
+  CYPRESS_VERSION 
+  K3D_DEV_LOCAL_DEPLOYMENT_MODE
+'
+
+for var in $REQUIRED_VARS; do
+  if [ -z "${!var}" ]; then 
+    echo "Error: variable $var needs to be set"
+    exit 1
+  fi
+done
+
+echo "Using following values:"
+for var in $REQUIRED_VARS; do
+  echo "  ${var}: ${!var}"
+done
+
+CYPRESS_VERSION=$CYPRESS_VERSION \
+WORKSPACE_PATH=$WORKSPACE_PATH \
+K3D_DEV_LOCAL_DEPLOYMENT_MODE=$K3D_DEV_LOCAL_DEPLOYMENT_MODE \
+  docker compose \
+    -f .docker/docker-compose.common.yml \
+    -f .docker/docker-compose.e2e.ci.yml \
+    up \
+    -d

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,11 +15,4 @@ else
 fi
 cd ..
 
-# echo "MS LOGS"
-# kubectl -n ms logs $(kubectl -n ms get po -o yaml | yq '.items[].metadata.name | select(. == "ms-*")')
-# echo "WEB SERVER LOGS"
-# kubectl -n api logs $(kubectl -n api get po -o yaml | yq '.items[].metadata.name | select(. == "web-server-*")')
-# echo "POSTGRES STOREAGE LOGS"
-# kubectl -n ms logs $(kubectl -n ms get po -o yaml | yq '.items[].metadata.name | select(. == "*postgres*")')
-
 exit $test_exit_code

--- a/src/targets/aws/dev/eu-central-1/vault/terragrunt.hcl
+++ b/src/targets/aws/dev/eu-central-1/vault/terragrunt.hcl
@@ -127,9 +127,9 @@ inputs = {
   ingress_sg = dependency.aws_vpc.outputs.aws_alb_security_group_id
 
   // TODO get rid of these
-  intermediate_crt_b64 = base64encode(file("${get_repo_root()}/.certs/intermediate/intermediate.crt"))
-  intermediate_key_b64 = base64encode(file("${get_repo_root()}/.certs/intermediate/intermediate.key"))
-  ca_crt_b64           = base64encode(file("${get_repo_root()}/.certs/root/root.crt"))
+  intermediate_crt_b64 = base64encode(file("${get_repo_root()}/.certs/intermediate/tls.crt"))
+  intermediate_key_b64 = base64encode(file("${get_repo_root()}/.certs/intermediate/tls.key"))
+  ca_crt_b64           = base64encode(file("${get_repo_root()}/.certs/intermediate/ca.crt"))
 }
 
 terraform {

--- a/src/targets/aws/terragrunt.platform.hcl
+++ b/src/targets/aws/terragrunt.platform.hcl
@@ -3,9 +3,22 @@ inputs = {
 
   // TODO this is pretty much invalid config that clashes with requirements of the cloud.
   // find a better way of handling these
-  intermediate_crt_b64 = base64encode(file("${get_repo_root()}/.certs/intermediate/intermediate.crt"))
-  intermediate_key_b64 = base64encode(file("${get_repo_root()}/.certs/intermediate/intermediate.key"))
-  ca_crt_b64           = base64encode(file("${get_repo_root()}/.certs/root/root.crt"))
+  intermediate_crt_b64 = base64encode(file(join("/", [
+    local.certs_path,
+    "intermediate/tls.crt"
+  ])))
+  intermediate_key_b64 = base64encode(file(join("/", [
+    local.certs_path,
+    "intermediate/tls.key"
+  ])))
+  ca_crt_b64 = base64encode(file(join("/", [
+    local.certs_path,
+    "intermediate/ca.crt"
+  ])))
+}
+
+locals {
+  certs_path = "${get_repo_root()}/.certs"
 }
 
 retryable_errors = [

--- a/src/targets/k3d/dev/local/services/terragrunt.hcl
+++ b/src/targets/k3d/dev/local/services/terragrunt.hcl
@@ -34,7 +34,7 @@ dependencies {
 }
 
 inputs = {
-  web_server_image_tag = get_env("WEB_SERVER_IMAGE_TAG")
-  ms_image_tag         = get_env("MS_IMAGE_TAG")
+  web_server_image_tag = get_env("WEB_SERVER_IMAGE_TAG", "")
+  ms_image_tag         = get_env("MS_IMAGE_TAG", "")
   ingress_sg           = "DOES_NOT_APPLY_IN_K3D"
 }

--- a/src/targets/k3d/dev/local/terragrunt.region.hcl
+++ b/src/targets/k3d/dev/local/terragrunt.region.hcl
@@ -1,8 +1,5 @@
 inputs = {
-  deployment_mode = "all"
-  // deployment_mode = "no_observability"
-  // deployment_mode   = "grafana"
-  // deployment_mode   = "web_server"
+  deployment_mode   = get_env("K3D_DEV_LOCAL_DEPLOYMENT_MODE", "all")
   helm_timeout_unit = 180
   helm_atomic       = true
   api_run_mode      = "production"

--- a/src/targets/k3d/terragrunt.platform.hcl
+++ b/src/targets/k3d/terragrunt.platform.hcl
@@ -8,15 +8,15 @@ inputs = {
   // find a better way of handling these
   intermediate_crt_b64 = base64encode(file(join("/", [
     local.certs_path,
-    "intermediate/intermediate.crt"
+    "intermediate/tls.crt"
   ])))
   intermediate_key_b64 = base64encode(file(join("/", [
     local.certs_path,
-    "intermediate/intermediate.key"
+    "intermediate/tls.key"
   ])))
   ca_crt_b64 = base64encode(file(join("/", [
     local.certs_path,
-    "root/root.crt"
+    "intermediate/ca.crt"
   ])))
 }
 

--- a/tests/k3d_dev_local_test.go
+++ b/tests/k3d_dev_local_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -21,9 +20,8 @@ func TestK3dDevLocal(t *testing.T) {
 }
 
 func kubernetesTests(t *testing.T) {
+	defer test_structure.RunTestStage(t, "logs", LogTests(t))
 	test_structure.RunTestStage(t, "ingress", IngressTests(t))
 	test_structure.RunTestStage(t, "observability", ObservabilityTests(t))
 	test_structure.RunTestStage(t, "endpoint", EndpointTests(t))
-	fmt.Println("Starting log retrieval...")
-	test_structure.RunTestStage(t, "logs", LogTests(t))
 }


### PR DESCRIPTION
- Integrate with nextjs-grpc-e2e to start e2e testing.
- Update Actions commands to trigger e2e testing on push and pr.
- Update workflow names to better reflect what the workflows do in a
  standardized way.
- Fix bug with inputs in integrations tests; where `...Ref` values were
  mistyped.
- Upgrade the devcontainer to the newest experimental version.
- Add infracost config and run script. This is just a test commit for
  this feature. The usage values don't make any sense for now.
- Add script files for infrastructure creation.
